### PR TITLE
fix(dump error)： 1. 当自定义的表名与系统的表名冲突时，出现异常，导致后续的表中断导出;

### DIFF
--- a/mysqldump.go
+++ b/mysqldump.go
@@ -211,7 +211,7 @@ func Dump(dns string, opts ...DumpOption) error {
 
 func getCreateTableSQL(db *sql.DB, table string) (string, error) {
 	var createTableSQL string
-	err := db.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s", table)).Scan(&table, &createTableSQL)
+	err := db.QueryRow(fmt.Sprintf("SHOW CREATE TABLE `%s`", table)).Scan(&table, &createTableSQL)
 	if err != nil {
 		return "", err
 	}
@@ -284,7 +284,7 @@ func writeTableData(db *sql.DB, table string, buf *bufio.Writer) error {
 	buf.WriteString(fmt.Sprintf("-- Records of %s\n", table))
 	buf.WriteString("-- ----------------------------\n")
 
-	lineRows, err := db.Query(fmt.Sprintf("SELECT * FROM %s", table))
+	lineRows, err := db.Query(fmt.Sprintf("SELECT * FROM `%s`", table))
 	if err != nil {
 		log.Printf("[error] %v \n", err)
 		return err

--- a/source.go
+++ b/source.go
@@ -42,7 +42,6 @@ func NewDBWrapper(db *sql.DB, dryRun bool) *DBWrapper {
 }
 
 func (db *DBWrapper) Exec(query string, args ...interface{}) (sql.Result, error) {
-	fmt.Printf("[SQL] query: %s , args: %v \n", query, args)
 	if db.dryRun {
 		return nil, nil
 	}


### PR DESCRIPTION
1. 修复自定义表名称与系统的表名称相同时，导出表结构时出现异常导致中断；