### PR TITLE
导出脚本支持批量插入，提高大表的导出速度，默认导出不使用use database 语句，以防止导入时选库其他库时，导入错误的库

### DIFF
--- a/mysqldump.go
+++ b/mysqldump.go
@@ -31,7 +31,7 @@ type dumpOption struct {
 	isAllTable bool
 	// 是否删除表
 	isDropTable bool
-	// 是否增加选库脚本
+	// 是否增加选库脚本，多库导出时，此设置默认开启
 	isUseDb bool
 
 	//批量插入，提高导出效率


### PR DESCRIPTION
1、dump方法增加配置：
`
mysqldump.WithMultyInsert(1000)
`
其中1000 为表记录最大一条SQL语句插入1000行数据，默认时一条数据一条insert，导入时，速度较慢。
2、默认去掉use db;语句，如果需要，在dump方法内增加：
`
mysqldump.WithUseDb()
`
举例：导出A库的数据，然后我要用工具导入到测试库A1内，原来是实现不了的，现在导入时，工具先选择A1库，再执行脚本即可导入到A1库，

下个版本：
导出增加触发器支持
导出使用多协程，提高导出速度

